### PR TITLE
[Club] Configure static export

### DIFF
--- a/apps/club/next.config.js
+++ b/apps/club/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import("next").NextConfig} */
 const config = {
+  output: "export",
   reactStrictMode: true,
 
   /** Enables hot reloading for local packages without a build step */


### PR DESCRIPTION
# Why

The club site will be entirely static, so no need to run a Node.js/Bun server for this application, which will take up more resources than needed.

# What

This PR simply modifies the `next.config.js`, setting out to "export".

# Test Plan

Will see if this successfully deploys after merging.

