### PR TITLE
[FEPrep] Fix Tab Issue with Code Output and Test Cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ yarn-error.log*
 # local env files
 .env
 .env*.local
+.env-e
 
 # vercel
 .vercel

--- a/apps/feprep/src/app/problems/[id]/_components/monaco-editor.tsx
+++ b/apps/feprep/src/app/problems/[id]/_components/monaco-editor.tsx
@@ -75,15 +75,13 @@ int main()
             <TabsTrigger value="testcases">Test Cases</TabsTrigger>
           </TabsList>
           {/* Output Content */}
-          <TabsContent value="output" className="flex flex-1">
-            <div className="flex flex-1 border-2 border-accent">
-              <pre className="flex-1 overflow-auto bg-background p-2">
-                {output}
-              </pre>
-            </div>
+          <TabsContent value="output" className="h-full flex-1 border" asChild>
+            <pre>{output}</pre>
           </TabsContent>
           {/* Test Cases Content */}
-          <TabsContent value="testcases"></TabsContent>
+          <TabsContent value="testcases" className="h-full flex-1 border">
+            test cases
+          </TabsContent>
         </Tabs>
       </div>
     </div>


### PR DESCRIPTION
# Why

- Bottom tabs had a visual bug that was ignored in my last PR

# What

- Design remains consistent across both Output and Test Cases tab

# Test Plan

<img width="1651" alt="Screenshot 2024-11-18 at 10 50 54 PM" src="https://github.com/user-attachments/assets/bf641135-6ce6-4f5f-baf3-54a956e8398c">
<img width="1654" alt="Screenshot 2024-11-18 at 10 51 03 PM" src="https://github.com/user-attachments/assets/24d554fe-c84e-40c6-a596-c277333ba9a2">

