### PR TITLE
[FEPrep] Add navbar for problem page

### DIFF
--- a/apps/feprep/package.json
+++ b/apps/feprep/package.json
@@ -28,6 +28,7 @@
     "@trpc/server": "catalog:",
     "axios": "^1.7.7",
     "bun": "^1.1.33",
+    "framer-motion": "^11.11.17",
     "geist": "^1.3.1",
     "monaco-editor": "^0.52.0",
     "next": "^14.2.15",

--- a/apps/feprep/src/app/layout.tsx
+++ b/apps/feprep/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { GeistMono } from "geist/font/mono";
 import { GeistSans } from "geist/font/sans";
 
 import { cn } from "@blade/ui";
-import { ThemeProvider, ThemeToggle } from "@blade/ui/theme";
+import { ThemeProvider } from "@blade/ui/theme";
 import { Toaster } from "@blade/ui/toast";
 
 import { TRPCReactProvider } from "~/trpc/react";
@@ -52,9 +52,6 @@ export default function RootLayout(props: { children: React.ReactNode }) {
       >
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <TRPCReactProvider>{props.children}</TRPCReactProvider>
-          <div className="absolute bottom-4 right-4 z-50">
-            <ThemeToggle />
-          </div>
           <Toaster />
         </ThemeProvider>
       </body>

--- a/apps/feprep/src/app/problems/[id]/_components/excalidraw-wrapper.tsx
+++ b/apps/feprep/src/app/problems/[id]/_components/excalidraw-wrapper.tsx
@@ -1,7 +1,17 @@
 "use client";
 
-import { Excalidraw } from "@excalidraw/excalidraw";
+import dynamic from "next/dynamic";
 import { useTheme } from "next-themes";
+
+import { Skeleton } from "@blade/ui/skeleton";
+
+const Excalidraw = dynamic(
+  async () => (await import("@excalidraw/excalidraw")).Excalidraw,
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-full w-full" />,
+  },
+);
 
 export default function ExcalidrawWrapper() {
   const { resolvedTheme } = useTheme();

--- a/apps/feprep/src/app/problems/[id]/_components/navbar.tsx
+++ b/apps/feprep/src/app/problems/[id]/_components/navbar.tsx
@@ -1,0 +1,11 @@
+import Link from "next/link";
+
+export function Navbar() {
+  return (
+    <nav className="flex items-center justify-between px-4 py-2.5">
+      <Link href="/problems" className="text-xl font-bold">
+        <span>FEPrep</span>
+      </Link>
+    </nav>
+  );
+}

--- a/apps/feprep/src/app/problems/[id]/_components/navbar.tsx
+++ b/apps/feprep/src/app/problems/[id]/_components/navbar.tsx
@@ -1,11 +1,67 @@
 import Link from "next/link";
 
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  ListBulletIcon,
+  ShuffleIcon,
+} from "@blade/ui";
+import { Button } from "@blade/ui/button";
+import { Separator } from "@blade/ui/separator";
+
+import { Timer } from "./timer";
+import { ToggleSolution } from "./toggle-solution";
+
 export function Navbar() {
   return (
     <nav className="flex items-center justify-between px-4 py-2.5">
-      <Link href="/problems" className="text-xl font-bold">
-        <span>FEPrep</span>
-      </Link>
+      <div className="flex items-center gap-2">
+        <Link href="/problems" className="text-xl font-bold">
+          <span>FEPrep</span>
+        </Link>
+        <Separator orientation="vertical" className="mx-2 h-8" />
+        <div className="flex items-center">
+          <Button
+            variant="outline"
+            className="w-9 rounded-r-none px-0 focus-visible:bg-accent focus-visible:ring-0 lg:w-auto lg:px-4"
+          >
+            <ListBulletIcon className="lg:mr-2" />
+            <span className="hidden lg:inline">Questions</span>
+          </Button>
+          <Button
+            size="icon"
+            variant="outline"
+            className="rounded-l-none rounded-r-none border-l-0 focus-visible:bg-accent focus-visible:ring-0"
+          >
+            <ArrowLeftIcon />
+          </Button>
+          <Button
+            size="icon"
+            variant="outline"
+            className="rounded-l-none rounded-r-none border-l-0 focus-visible:bg-accent focus-visible:ring-0"
+          >
+            <ArrowRightIcon />
+          </Button>
+          <Button
+            size="icon"
+            variant="outline"
+            className="rounded-l-none border-l-0 focus-visible:bg-accent focus-visible:ring-0"
+          >
+            <ShuffleIcon />
+          </Button>
+        </div>
+      </div>
+      <div className="flex items-center gap-2">
+        <Timer />
+        <ToggleSolution />
+      </div>
+      <div className="flex items-center">
+        <Button asChild>
+          <Link href="/sign-in">
+            <span>Sign In</span>
+          </Link>
+        </Button>
+      </div>
     </nav>
   );
 }

--- a/apps/feprep/src/app/problems/[id]/_components/timer.tsx
+++ b/apps/feprep/src/app/problems/[id]/_components/timer.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+import {
+  ChevronLeftIcon,
+  LapTimerIcon,
+  PauseIcon,
+  PlayIcon,
+  ResetIcon,
+} from "@blade/ui";
+import { Button } from "@blade/ui/button";
+
+export function Timer() {
+  const [open, setOpen] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [secondsElapsed, setSecondsElapsed] = useState(0);
+
+  const minutes = String(Math.floor(secondsElapsed / 60)).padStart(2, "0");
+  const hours = String(Math.floor(Number(minutes) / 60)).padStart(2, "0");
+  const seconds = String(secondsElapsed % 60).padStart(2, "0");
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
+
+    if (isRunning) {
+      interval = setInterval(() => {
+        setSecondsElapsed((prev) => prev + 1);
+      }, 1000);
+    } else if (secondsElapsed !== 0) {
+      clearInterval(interval);
+    }
+
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+    };
+  });
+
+  return (
+    <AnimatePresence mode="popLayout" initial={false}>
+      {open ? (
+        <motion.div
+          key="hello"
+          className="flex items-center"
+          initial={{ opacity: 0, x: -100 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -100 }}
+        >
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-r-none"
+            onClick={() => setOpen(false)}
+          >
+            <ChevronLeftIcon />
+          </Button>
+          <Button
+            variant="outline"
+            className="rounded-l-none rounded-r-none border-l-0 border-r-0"
+            onClick={() => {
+              setIsRunning(!isRunning);
+            }}
+          >
+            <span className="mr-2">
+              {isRunning ? <PauseIcon /> : <PlayIcon />}
+            </span>
+            <span>
+              {hours}:{minutes}:{seconds}
+            </span>
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="rounded-l-none"
+            onClick={() => {
+              setSecondsElapsed(0);
+              setIsRunning(false);
+            }}
+          >
+            <ResetIcon />
+          </Button>
+        </motion.div>
+      ) : (
+        <motion.div
+          key="world"
+          initial={{ opacity: 0, x: 100 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: 100 }}
+        >
+          <Button variant="outline" size="icon" onClick={() => setOpen(true)}>
+            <LapTimerIcon />
+          </Button>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/feprep/src/app/problems/[id]/_components/toggle-solution.tsx
+++ b/apps/feprep/src/app/problems/[id]/_components/toggle-solution.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+
+import { RocketIcon } from "@blade/ui";
+import { Button } from "@blade/ui/button";
+
+export function ToggleSolution() {
+  const searchParams = useSearchParams();
+  const pageNumber = Number(searchParams.get("page"));
+  const pathname = usePathname();
+
+  return (
+    <Link href={`${pathname}?page=${pageNumber === 1 ? 2 : 1}`}>
+      <Button variant="outline" className="w-9 px-0 lg:w-auto lg:px-4">
+        <RocketIcon className="lg:mr-2" />
+        <span className="hidden lg:inline">
+          {pageNumber === 1 ? "Solution" : "Question"}
+        </span>
+      </Button>
+    </Link>
+  );
+}

--- a/apps/feprep/src/app/problems/[id]/page.tsx
+++ b/apps/feprep/src/app/problems/[id]/page.tsx
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@blade/ui/tabs";
 
 import IDE from "./_components/monaco-editor";
+import { Navbar } from "./_components/navbar";
 
 // Since client components get prerenderd on server as well hence importing
 // the excalidraw stuff dynamically with ssr false
@@ -17,8 +18,8 @@ const ExcalidrawWrapper = dynamic(
 export default function Problem() {
   return (
     <div className="flex h-screen flex-col">
-      <nav className="border p-4">navbar</nav>
-      <main className="flex flex-1 flex-col gap-2 p-2 md:flex-row">
+      <Navbar />
+      <main className="flex flex-1 flex-col gap-2 px-2 md:flex-row">
         <div className="min-h-full flex-1 overflow-hidden rounded-lg border">
           <object
             className="h-full w-full"

--- a/apps/feprep/src/app/problems/[id]/page.tsx
+++ b/apps/feprep/src/app/problems/[id]/page.tsx
@@ -4,7 +4,6 @@ import ExcalidrawWrapper from "./_components/excalidraw-wrapper";
 import IDE from "./_components/monaco-editor";
 import { Navbar } from "./_components/navbar";
 
-
 export default function Problem() {
   return (
     <div className="flex h-screen flex-col">

--- a/apps/feprep/src/app/problems/[id]/page.tsx
+++ b/apps/feprep/src/app/problems/[id]/page.tsx
@@ -1,19 +1,9 @@
-import dynamic from "next/dynamic";
-
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@blade/ui/tabs";
 
+import ExcalidrawWrapper from "./_components/excalidraw-wrapper";
 import IDE from "./_components/monaco-editor";
 import { Navbar } from "./_components/navbar";
 
-// Since client components get prerenderd on server as well hence importing
-// the excalidraw stuff dynamically with ssr false
-
-const ExcalidrawWrapper = dynamic(
-  async () => (await import("./_components/excalidraw-wrapper")).default,
-  {
-    ssr: false,
-  },
-);
 
 export default function Problem() {
   return (

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.2",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",
+    "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.1",
     "class-variance-authority": "^0.7.0",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,3 +4,4 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: Parameters<typeof cx>) => twMerge(cx(inputs));
 
 export { cn };
+export * from "@radix-ui/react-icons";

--- a/packages/ui/src/separator.tsx
+++ b/packages/ui/src/separator.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import * as React from "react";
+import * as SeparatorPrimitive from "@radix-ui/react-separator";
+
+import { cn } from "@blade/ui";
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref,
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/packages/ui/src/skeleton.tsx
+++ b/packages/ui/src/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from "@blade/ui";
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-primary/10", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,9 @@ importers:
       bun:
         specifier: ^1.1.33
         version: 1.1.33
+      framer-motion:
+        specifier: ^11.11.17
+        version: 11.11.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       geist:
         specifier: ^1.3.1
         version: 1.3.1(next@14.2.15(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
@@ -541,6 +544,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -1827,6 +1833,19 @@ packages:
 
   '@radix-ui/react-roving-focus@1.1.0':
     resolution: {integrity: sha512-EA6AMGeq9AEeQDeSH0aZgG198qkfHSbvWTf1HvoDmOB5bBG/qTxjYMWUKMnYiV6J/iP/J8MEFSuB2zRU2n7ODA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.0':
+    resolution: {integrity: sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3315,6 +3334,20 @@ packages:
   form-data@4.0.1:
     resolution: {integrity: sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==}
     engines: {node: '>= 6'}
+
+  framer-motion@11.11.17:
+    resolution: {integrity: sha512-O8QzvoKiuzI5HSAHbcYuL6xU+ZLXbrH7C8Akaato4JzQbX2ULNeniqC2Vo5eiCtFktX9XsJ+7nUhxcl2E2IjpA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0
+      react-dom: ^18.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
@@ -5197,9 +5230,6 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
-  tslib@2.7.0:
-    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
-
   tslib@2.8.0:
     resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
 
@@ -6441,6 +6471,15 @@ snapshots:
       '@types/react': 18.3.11
       '@types/react-dom': 18.3.1
 
+  '@radix-ui/react-separator@1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.1)(@types/react@18.3.11)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.11
+      '@types/react-dom': 18.3.1
+
   '@radix-ui/react-slot@1.1.0(@types/react@18.3.11)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.11)(react@18.3.1)
@@ -6630,7 +6669,7 @@ snapshots:
   '@swc/helpers@0.5.5':
     dependencies:
       '@swc/counter': 0.1.3
-      tslib: 2.7.0
+      tslib: 2.8.0
 
   '@t3-oss/env-core@0.11.1(typescript@5.6.3)(zod@3.23.8)':
     dependencies:
@@ -6998,7 +7037,7 @@ snapshots:
 
   aria-hidden@1.2.4:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.0
 
   aria-query@5.1.3:
     dependencies:
@@ -8069,6 +8108,13 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  framer-motion@11.11.17(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      tslib: 2.8.0
+    optionalDependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   fresh@0.5.2: {}
 
@@ -9517,7 +9563,7 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-style-singleton: 2.2.1(@types/react@18.3.11)(react@18.3.1)
-      tslib: 2.7.0
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -9526,7 +9572,7 @@ snapshots:
       react: 18.3.1
       react-remove-scroll-bar: 2.3.6(@types/react@18.3.11)(react@18.3.1)
       react-style-singleton: 2.2.1(@types/react@18.3.11)(react@18.3.1)
-      tslib: 2.7.0
+      tslib: 2.8.0
       use-callback-ref: 1.3.2(@types/react@18.3.11)(react@18.3.1)
       use-sidecar: 1.1.2(@types/react@18.3.11)(react@18.3.1)
     optionalDependencies:
@@ -9537,7 +9583,7 @@ snapshots:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.3.1
-      tslib: 2.7.0
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -9689,7 +9735,7 @@ snapshots:
 
   rxjs@7.8.1:
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.0
 
   safe-array-concat@1.1.2:
     dependencies:
@@ -10170,8 +10216,6 @@ snapshots:
 
   tslib@1.14.1: {}
 
-  tslib@2.7.0: {}
-
   tslib@2.8.0: {}
 
   turbo-darwin-64@2.1.3:
@@ -10384,7 +10428,7 @@ snapshots:
   use-callback-ref@1.3.2(@types/react@18.3.11)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      tslib: 2.7.0
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -10392,7 +10436,7 @@ snapshots:
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1
-      tslib: 2.7.0
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.11
 


### PR DESCRIPTION
# Why

We need to migrate the navbar for the problems page from the old site

# What

This PR migrates the old navbar component from the old site with a few changes:
- slightly shorter
- no bottom border
- shows list icon when on mobile for the questions button
- state for page number is stored as a query param
- lint checks regarding always truthy or always falsy were fixed

# Test Plan

![image](https://github.com/user-attachments/assets/0bfb4607-e33f-4f8a-98aa-5088fae60293)
