### PR TITLE
[Repo] Update CODEOWNERS to include dev team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 /apps/feprep @KnightHacks/feprep
+/* @KnightHacks/dev


### PR DESCRIPTION
# Why

This will ping the dev team to review changes to all code that isn't in `/apps/feprep`, which will help give more eyes on changes to the monorepo.

# What

Adds a second rule to the `CODEOWNERS` file, indicating all files other than the ones in `/apps/feprep` are owners by the Knight Hacks dev team.

# Test Plan

Will test if this pings dev team on future PRs to code that lives outside of `/apps/feprep`.
